### PR TITLE
Update Linter Configuration File

### DIFF
--- a/ruby-on-rails/.github/workflows/linters.yml
+++ b/ruby-on-rails/.github/workflows/linters.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2.x
+          ruby-version: 3.2.2
       - name: Setup Rubocop
         run: |
           gem install --no-document rubocop -v '>= 1.0, < 2.0' # https://docs.rubocop.org/en/stable/installation/


### PR DESCRIPTION
# Changes made ⚒️

- Replaced deprecated action `actions/setup-ruby@v1` with `ruby/setup-ruby@v1`.
- Changed ruby-version to **3.2.2**.